### PR TITLE
feat: support setting function modules for xrpc

### DIFF
--- a/t/util/http_handler.lua
+++ b/t/util/http_handler.lua
@@ -1,0 +1,18 @@
+local http = require('resty.http')
+local json = require('cjson')
+
+return function (node, conf)
+    ngx.log(ngx.INFO, "http_handler node: ", json.encode(node), " conf: ", json.encode(conf))
+    conf = conf or {}
+    local httpc = http.new()
+    local uri = "http://" .. node.host .. ":" .. node.port
+    local res, err = httpc:request_uri(uri, {
+        method = conf.method or "GET",
+        path = conf.path or "/status",
+    })
+    if not res then
+        ngx.log(ngx.ERR, "failed to request: ", err)
+        return false
+    end
+    return true, res.status
+end


### PR DESCRIPTION
xrpc_function_module: Module for loading functions

```lua
local checker, err = healthcheck.new({
    name = "testing",
    shm_name = "test_shm",
    type = "xrpc",
    checks = {
        active = {
            healthy  = {
                interval = 0.5, -- we don't want active checks
                successes = 2,
            },
            unhealthy  = {
                interval = 0.5, -- we don't want active checks
                failures = 2,
            },
            xrpc_function_module = "util.http_handler",
        },
    },
})
```